### PR TITLE
fix: replace Japanese comments with English and optimize string concatenation

### DIFF
--- a/.trigger-ci
+++ b/.trigger-ci
@@ -1,0 +1,1 @@
+trigger CI run

--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -1,3 +1,4 @@
+// Package analyzer provides static analysis for effect tracking in Go code
 package analyzer
 
 import (
@@ -19,10 +20,10 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	inspector := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 
 	// Create effect analysis
-	effectAnalysis := NewEffectAnalysis(pass, inspector)
+	effectAnalysis := NewEffectAnalysis(pass, insp)
 
 	// Load JSON effects if available
 	jsonPath := os.Getenv("DIRTY_EFFECTS_JSON")
@@ -83,4 +84,3 @@ func ParseEffects(comment string) []string {
 	// Convert to sorted slice
 	return set.ToSlice()
 }
-

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -75,6 +75,6 @@ func equalStringSlices(a, b []string) bool {
 	return true
 }
 
-func TestCheckFunctionEffects(t *testing.T) {
+func TestCheckFunctionEffects(_ *testing.T) {
 	// TODO: Add tests for function effect checking
 }

--- a/analyzer/ast.go
+++ b/analyzer/ast.go
@@ -20,6 +20,7 @@ type EffectLabel struct {
 	Target    string // "users", "logs", etc.
 }
 
+// Eval evaluates the effect label and returns a set containing this single effect
 func (e *EffectLabel) Eval(resolver EffectResolver) (StringSet, error) {
 	return NewStringSet(e.String()), nil
 }
@@ -34,6 +35,7 @@ type LiteralSet struct {
 	Elements []EffectExpr // Slice of elements in the set
 }
 
+// Eval evaluates the literal set by unioning all its element effects
 func (s *LiteralSet) Eval(resolver EffectResolver) (StringSet, error) {
 	result := NewStringSet()
 	for _, elem := range s.Elements {
@@ -63,6 +65,7 @@ type EffectRef struct {
 	Name string
 }
 
+// Eval evaluates the effect reference by resolving it through the provided resolver
 func (r *EffectRef) Eval(resolver EffectResolver) (StringSet, error) {
 	if resolver == nil {
 		return nil, fmt.Errorf("cannot resolve effect reference '%s': no resolver provided", r.Name)
@@ -82,6 +85,7 @@ type EffectResolver interface {
 // NilResolver is a resolver that always returns an error
 type NilResolver struct{}
 
+// Resolve always returns an error since NilResolver doesn't support effect references
 func (NilResolver) Resolve(name string) (StringSet, error) {
 	return nil, fmt.Errorf("effect reference '%s' not supported in Phase 1", name)
 }

--- a/analyzer/ast.go
+++ b/analyzer/ast.go
@@ -21,7 +21,7 @@ type EffectLabel struct {
 }
 
 // Eval evaluates the effect label and returns a set containing this single effect
-func (e *EffectLabel) Eval(resolver EffectResolver) (StringSet, error) {
+func (e *EffectLabel) Eval(_ EffectResolver) (StringSet, error) {
 	return NewStringSet(e.String()), nil
 }
 

--- a/analyzer/effect_analysis.go
+++ b/analyzer/effect_analysis.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"go/ast"
 	"os"
+	"strings"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/ast/inspector"
@@ -232,12 +233,5 @@ func (ea *EffectAnalysis) CheckEffects() {
 
 // joinEffects joins effect strings for error messages
 func joinEffects(effects []string) string {
-	result := ""
-	for i, effect := range effects {
-		if i > 0 {
-			result += ", "
-		}
-		result += effect
-	}
-	return result
+	return strings.Join(effects, ", ")
 }

--- a/analyzer/effect_declarations.go
+++ b/analyzer/effect_declarations.go
@@ -14,6 +14,7 @@ type EffectDeclarations struct {
 
 // LoadEffectDeclarations loads effect declarations from JSON
 func LoadEffectDeclarations(path string) (*EffectDeclarations, error) {
+	// #nosec G304 - path is controlled by DIRTY_EFFECTS_JSON env var or package directory
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err

--- a/analyzer/lexer.go
+++ b/analyzer/lexer.go
@@ -10,7 +10,7 @@ type TokenType int
 
 // TokenType constants define the types of tokens in effect expressions
 const (
-	TokenEOF     TokenType = iota
+	TokenEOF TokenType = iota
 	TokenLBrace      // {
 	TokenRBrace      // }
 	TokenLParen      // (

--- a/analyzer/lexer.go
+++ b/analyzer/lexer.go
@@ -10,16 +10,16 @@ type TokenType int
 
 // TokenType constants define the types of tokens in effect expressions
 const (
-	TokenEOF TokenType = iota
-	TokenLBrace      // {
-	TokenRBrace      // }
-	TokenLParen      // (
-	TokenRParen      // )
-	TokenPipe        // |
-	TokenLBracket    // [
-	TokenRBracket    // ]
-	TokenIdent       // identifier
-	TokenIllegal     // illegal token
+	TokenEOF      TokenType = iota
+	TokenLBrace              // {
+	TokenRBrace              // }
+	TokenLParen              // (
+	TokenRParen              // )
+	TokenPipe                // |
+	TokenLBracket            // [
+	TokenRBracket            // ]
+	TokenIdent               // identifier
+	TokenIllegal             // illegal token
 )
 
 // Token represents a lexical token

--- a/analyzer/lexer.go
+++ b/analyzer/lexer.go
@@ -8,17 +8,18 @@ import (
 // TokenType represents the type of a token
 type TokenType int
 
+// TokenType constants define the types of tokens in effect expressions
 const (
-	TOKEN_EOF TokenType = iota
-	TOKEN_LBRACE      // {
-	TOKEN_RBRACE      // }
-	TOKEN_LPAREN      // (
-	TOKEN_RPAREN      // )
-	TOKEN_PIPE        // |
-	TOKEN_LBRACKET    // [
-	TOKEN_RBRACKET    // ]
-	TOKEN_IDENT       // identifier
-	TOKEN_ILLEGAL     // illegal token
+	TokenEOF TokenType = iota
+	TokenLBrace      // {
+	TokenRBrace      // }
+	TokenLParen      // (
+	TokenRParen      // )
+	TokenPipe        // |
+	TokenLBracket    // [
+	TokenRBracket    // ]
+	TokenIdent       // identifier
+	TokenIllegal     // illegal token
 )
 
 // Token represents a lexical token
@@ -52,13 +53,6 @@ func (l *Lexer) readChar() {
 	l.pos++
 }
 
-// peekChar returns the next character without advancing
-func (l *Lexer) peekChar() rune {
-	if l.pos >= len(l.input) {
-		return 0
-	}
-	return rune(l.input[l.pos])
-}
 
 // skipWhitespace skips whitespace characters
 func (l *Lexer) skipWhitespace() {
@@ -73,7 +67,7 @@ func (l *Lexer) readIdentifier() string {
 	for isLetter(l.ch) || isDigit(l.ch) || l.ch == '_' || l.ch == '-' || l.ch == '.' {
 		l.readChar()
 	}
-	return l.input[start:l.pos-1]
+	return l.input[start : l.pos-1]
 }
 
 // NextToken returns the next token
@@ -86,43 +80,43 @@ func (l *Lexer) NextToken() Token {
 
 	switch l.ch {
 	case '{':
-		tok.Type = TOKEN_LBRACE
+		tok.Type = TokenLBrace
 		tok.Value = "{"
 		l.readChar()
 	case '}':
-		tok.Type = TOKEN_RBRACE
+		tok.Type = TokenRBrace
 		tok.Value = "}"
 		l.readChar()
 	case '(':
-		tok.Type = TOKEN_LPAREN
+		tok.Type = TokenLParen
 		tok.Value = "("
 		l.readChar()
 	case ')':
-		tok.Type = TOKEN_RPAREN
+		tok.Type = TokenRParen
 		tok.Value = ")"
 		l.readChar()
 	case '|':
-		tok.Type = TOKEN_PIPE
+		tok.Type = TokenPipe
 		tok.Value = "|"
 		l.readChar()
 	case '[':
-		tok.Type = TOKEN_LBRACKET
+		tok.Type = TokenLBracket
 		tok.Value = "["
 		l.readChar()
 	case ']':
-		tok.Type = TOKEN_RBRACKET
+		tok.Type = TokenRBracket
 		tok.Value = "]"
 		l.readChar()
 	case 0:
-		tok.Type = TOKEN_EOF
+		tok.Type = TokenEOF
 		tok.Value = ""
 	default:
 		if isLetter(l.ch) {
 			tok.Value = l.readIdentifier()
-			tok.Type = TOKEN_IDENT
+			tok.Type = TokenIdent
 			return tok
 		}
-		tok.Type = TOKEN_ILLEGAL
+		tok.Type = TokenIllegal
 		tok.Value = string(l.ch)
 		l.readChar()
 	}
@@ -143,25 +137,25 @@ func isDigit(ch rune) bool {
 // TokenString returns a string representation of a token type
 func TokenString(t TokenType) string {
 	switch t {
-	case TOKEN_EOF:
+	case TokenEOF:
 		return "EOF"
-	case TOKEN_LBRACE:
+	case TokenLBrace:
 		return "{"
-	case TOKEN_RBRACE:
+	case TokenRBrace:
 		return "}"
-	case TOKEN_LPAREN:
+	case TokenLParen:
 		return "("
-	case TOKEN_RPAREN:
+	case TokenRParen:
 		return ")"
-	case TOKEN_PIPE:
+	case TokenPipe:
 		return "|"
-	case TOKEN_LBRACKET:
+	case TokenLBracket:
 		return "["
-	case TOKEN_RBRACKET:
+	case TokenRBracket:
 		return "]"
-	case TOKEN_IDENT:
+	case TokenIdent:
 		return "IDENT"
-	case TOKEN_ILLEGAL:
+	case TokenIllegal:
 		return "ILLEGAL"
 	default:
 		return fmt.Sprintf("UNKNOWN(%d)", t)
@@ -170,7 +164,7 @@ func TokenString(t TokenType) string {
 
 // String returns a string representation of a token
 func (t Token) String() string {
-	if t.Type == TOKEN_IDENT || t.Type == TOKEN_ILLEGAL {
+	if t.Type == TokenIdent || t.Type == TokenIllegal {
 		return fmt.Sprintf("%s(%s)", TokenString(t.Type), t.Value)
 	}
 	return TokenString(t.Type)

--- a/analyzer/lexer.go
+++ b/analyzer/lexer.go
@@ -53,7 +53,6 @@ func (l *Lexer) readChar() {
 	l.pos++
 }
 
-
 // skipWhitespace skips whitespace characters
 func (l *Lexer) skipWhitespace() {
 	for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {

--- a/analyzer/lexer.go
+++ b/analyzer/lexer.go
@@ -10,16 +10,16 @@ type TokenType int
 
 // TokenType constants define the types of tokens in effect expressions
 const (
-	TokenEOF      TokenType = iota
-	TokenLBrace              // {
-	TokenRBrace              // }
-	TokenLParen              // (
-	TokenRParen              // )
-	TokenPipe                // |
-	TokenLBracket            // [
-	TokenRBracket            // ]
-	TokenIdent               // identifier
-	TokenIllegal             // illegal token
+	TokenEOF TokenType = iota
+	TokenLBrace      // {
+	TokenRBrace      // }
+	TokenLParen      // (
+	TokenRParen      // )
+	TokenPipe        // |
+	TokenLBracket    // [
+	TokenRBracket    // ]
+	TokenIdent       // identifier
+	TokenIllegal     // illegal token
 )
 
 // Token represents a lexical token

--- a/analyzer/lexer.go
+++ b/analyzer/lexer.go
@@ -10,7 +10,7 @@ type TokenType int
 
 // TokenType constants define the types of tokens in effect expressions
 const (
-	TokenEOF TokenType = iota
+	TokenEOF     TokenType = iota
 	TokenLBrace      // {
 	TokenRBrace      // }
 	TokenLParen      // (

--- a/analyzer/parser.go
+++ b/analyzer/parser.go
@@ -52,13 +52,13 @@ func ParseEffectDecl(comment string) (EffectExpr, error) {
 
 // parseSetExpr parses a set expression: { ... }
 func (p *Parser) parseSetExpr() (EffectExpr, error) {
-	if p.cur.Type != TOKEN_LBRACE {
+	if p.cur.Type != TokenLBrace {
 		return nil, fmt.Errorf("expected '{' at position %d, got %s", p.cur.Pos, p.cur.String())
 	}
 	p.nextToken() // skip {
 
 	// Handle empty set
-	if p.cur.Type == TOKEN_RBRACE {
+	if p.cur.Type == TokenRBrace {
 		p.nextToken() // skip }
 		return &LiteralSet{Elements: []EffectExpr{}}, nil
 	}
@@ -73,12 +73,12 @@ func (p *Parser) parseSetExpr() (EffectExpr, error) {
 		elements = append(elements, elem)
 
 		// Check for | or }
-		if p.cur.Type == TOKEN_PIPE {
+		if p.cur.Type == TokenPipe {
 			p.nextToken() // skip |
 			continue
 		}
 
-		if p.cur.Type == TOKEN_RBRACE {
+		if p.cur.Type == TokenRBrace {
 			p.nextToken() // skip }
 			break
 		}
@@ -92,22 +92,22 @@ func (p *Parser) parseSetExpr() (EffectExpr, error) {
 // parsePrimary parses a primary expression
 func (p *Parser) parsePrimary() (EffectExpr, error) {
 	switch p.cur.Type {
-	case TOKEN_IDENT:
+	case TokenIdent:
 		// Could be an effect label or effect reference
 		ident := p.cur.Value
 		p.nextToken()
 
-		if p.cur.Type == TOKEN_LBRACKET {
+		if p.cur.Type == TokenLBracket {
 			// Effect label: operation[target]
 			p.nextToken() // skip [
 
-			if p.cur.Type != TOKEN_IDENT {
+			if p.cur.Type != TokenIdent {
 				return nil, fmt.Errorf("expected identifier after '[' at position %d, got %s", p.cur.Pos, p.cur.String())
 			}
 			target := p.cur.Value
 			p.nextToken()
 
-			if p.cur.Type != TOKEN_RBRACKET {
+			if p.cur.Type != TokenRBracket {
 				return nil, fmt.Errorf("expected ']' at position %d, got %s", p.cur.Pos, p.cur.String())
 			}
 			p.nextToken() // skip ]
@@ -121,14 +121,14 @@ func (p *Parser) parsePrimary() (EffectExpr, error) {
 		// Effect reference (Phase 2, but parse it anyway)
 		return &EffectRef{Name: ident}, nil
 
-	case TOKEN_LPAREN:
+	case TokenLParen:
 		// Parenthesized expression
 		p.nextToken() // skip (
 		expr, err := p.parseUnionExpr()
 		if err != nil {
 			return nil, err
 		}
-		if p.cur.Type != TOKEN_RPAREN {
+		if p.cur.Type != TokenRParen {
 			return nil, fmt.Errorf("expected ')' at position %d, got %s", p.cur.Pos, p.cur.String())
 		}
 		p.nextToken() // skip )
@@ -150,7 +150,7 @@ func (p *Parser) parseUnionExpr() (EffectExpr, error) {
 		}
 		elements = append(elements, elem)
 
-		if p.cur.Type != TOKEN_PIPE {
+		if p.cur.Type != TokenPipe {
 			break
 		}
 		p.nextToken() // skip |

--- a/analyzer/testutil/testutil.go
+++ b/analyzer/testutil/testutil.go
@@ -1,3 +1,4 @@
+// Package testutil provides utility functions for testing the dirty analyzer
 package testutil
 
 import (

--- a/cmd/dirty-verbose/main.go
+++ b/cmd/dirty-verbose/main.go
@@ -1,3 +1,4 @@
+// Package main provides the verbose dirty effect analyzer CLI tool
 package main
 
 import (

--- a/cmd/dirty-verbose/main.go
+++ b/cmd/dirty-verbose/main.go
@@ -16,7 +16,9 @@ func main() {
 
 	if *verbose {
 		// Set environment variable for analyzer to detect
-		os.Setenv("DIRTY_VERBOSE", "1")
+		if err := os.Setenv("DIRTY_VERBOSE", "1"); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to set DIRTY_VERBOSE: %v\n", err)
+		}
 	}
 
 	// Print usage if verbose

--- a/cmd/dirty/main.go
+++ b/cmd/dirty/main.go
@@ -1,3 +1,4 @@
+// Package main provides the main dirty effect analyzer CLI tool
 package main
 
 import (

--- a/cmd/fullvet/main.go
+++ b/cmd/fullvet/main.go
@@ -4,7 +4,7 @@ import (
 	"github.com/naoyafurudono/dirty/analyzer"
 	"golang.org/x/tools/go/analysis/unitchecker"
 
-	// 標準的なvetチェッカーをインポート
+	// Import standard vet checkers
 	"golang.org/x/tools/go/analysis/passes/asmdecl"
 	"golang.org/x/tools/go/analysis/passes/assign"
 	"golang.org/x/tools/go/analysis/passes/atomic"
@@ -31,9 +31,9 @@ import (
 )
 
 func main() {
-	// 標準のvetチェッカーとdirtyを組み合わせる
+	// Combine standard vet checkers with dirty
 	unitchecker.Main(
-		// 標準のチェッカー
+		// Standard checkers
 		asmdecl.Analyzer,
 		assign.Analyzer,
 		atomic.Analyzer,
@@ -58,7 +58,7 @@ func main() {
 		unsafeptr.Analyzer,
 		unusedresult.Analyzer,
 
-		// dirtyアナライザーを追加
+		// Add dirty analyzer
 		analyzer.Analyzer,
 	)
 }

--- a/cmd/fullvet/main.go
+++ b/cmd/fullvet/main.go
@@ -1,3 +1,4 @@
+// Package main provides a full vet tool combining standard checkers with dirty effect analysis
 package main
 
 import (

--- a/cmd/vet-dirty/main.go
+++ b/cmd/vet-dirty/main.go
@@ -6,6 +6,6 @@ import (
 )
 
 func main() {
-	// unitcheckerはgo vetと同じインターフェースを提供
+	// unitchecker provides the same interface as go vet
 	unitchecker.Main(analyzer.Analyzer)
 }

--- a/cmd/vet-dirty/main.go
+++ b/cmd/vet-dirty/main.go
@@ -1,3 +1,4 @@
+// Package main provides a go vet compatible interface for dirty effect analysis
 package main
 
 import (

--- a/example/complex_chain.go
+++ b/example/complex_chain.go
@@ -1,22 +1,25 @@
+// Package example demonstrates complex effect chaining scenarios
 package example
 
-// Base effects
+// LoadConfig loads configuration with config selection effects
 // dirty: { select[config] }
 func LoadConfig() error {
 	return nil
 }
 
+// GetUserData retrieves user data with user selection effects
 // dirty: { select[user] }
-func GetUserData(id int64) error {
+func GetUserData(_ int64) error {
 	return nil
 }
 
+// WriteAuditLog writes audit logs with audit insertion effects
 // dirty: { insert[audit] }
-func WriteAuditLog(msg string) error {
+func WriteAuditLog(_ string) error {
 	return nil
 }
 
-// チェーン1: 設定を読み込んでユーザーを取得
+// LoadUserWithConfig loads config and retrieves user data (chain 1: load config and get user)
 func LoadUserWithConfig(id int64) error {
 	if err := LoadConfig(); err != nil {
 		return err
@@ -24,7 +27,7 @@ func LoadUserWithConfig(id int64) error {
 	return GetUserData(id)
 }
 
-// チェーン2: ユーザーを取得して監査ログを書く
+// GetUserWithAudit gets user data and writes audit log (chain 2: get user and write audit)
 func GetUserWithAudit(id int64) error {
 	if err := GetUserData(id); err != nil {
 		return err
@@ -32,7 +35,7 @@ func GetUserWithAudit(id int64) error {
 	return WriteAuditLog("user accessed")
 }
 
-// チェーン3: すべてを組み合わせる
+// ComplexOperation combines all operations (chain 3: combine everything)
 func ComplexOperation(id int64) error {
 	if err := LoadUserWithConfig(id); err != nil {
 		return err
@@ -40,7 +43,7 @@ func ComplexOperation(id int64) error {
 	return GetUserWithAudit(id)
 }
 
-// エラー: 深い呼び出しチェーンのエフェクトが不足
+// BrokenDeepChain demonstrates missing effects in deep call chains (error: missing effects in deep call chain)
 // dirty: { insert[audit] }
 func BrokenDeepChain(id int64) error {
 	// ComplexOperationは以下のエフェクトを持つ:

--- a/example/jsoneffects/example.go
+++ b/example/jsoneffects/example.go
@@ -77,12 +77,27 @@ func UseHelper(userID string) error {
 
 // GetUserFromDB retrieves user data from database (declared in JSON)
 func GetUserFromDB(_ string) error { return nil }
+
+// CreateUserInDB creates a new user in the database
 func CreateUserInDB(_ string) error { return nil }
+
+// UpdateUserStatusInDB updates user status in the database
 func UpdateUserStatusInDB(_, _ string) error { return nil }
+
+// DeleteUserFromDB removes a user from the database
 func DeleteUserFromDB(_ string) error { return nil }
+
+// SendEmailNotification sends an email notification to the user
 func SendEmailNotification(_ string) error { return nil }
+
 // CallExternalAPI makes external API calls
 func CallExternalAPI() (string, error) { return "", nil }
-func ValidateUserInput(email string) error { return nil }
+
+// ValidateUserInput validates user input data
+func ValidateUserInput(_ string) error { return nil }
+
+// ComputeHash computes a hash of the given data
 func ComputeHash(_ string) string { return "" }
+
+// LogActivity logs an activity event
 func LogActivity(_ string) {}

--- a/example/jsoneffects/example.go
+++ b/example/jsoneffects/example.go
@@ -1,3 +1,4 @@
+// Package main demonstrates JSON-based effect declarations
 package main
 
 import "fmt"
@@ -74,13 +75,14 @@ func UseHelper(userID string) error {
 	return nil
 }
 
-// Functions that are declared in JSON but defined as stubs here
-func GetUserFromDB(email string) error { return nil }
-func CreateUserInDB(email string) error { return nil }
-func UpdateUserStatusInDB(userID, status string) error { return nil }
-func DeleteUserFromDB(userID string) error { return nil }
-func SendEmailNotification(email string) error { return nil }
+// GetUserFromDB retrieves user data from database (declared in JSON)
+func GetUserFromDB(_ string) error { return nil }
+func CreateUserInDB(_ string) error { return nil }
+func UpdateUserStatusInDB(_, _ string) error { return nil }
+func DeleteUserFromDB(_ string) error { return nil }
+func SendEmailNotification(_ string) error { return nil }
+// CallExternalAPI makes external API calls
 func CallExternalAPI() (string, error) { return "", nil }
 func ValidateUserInput(email string) error { return nil }
-func ComputeHash(data string) string { return "" }
-func LogActivity(activity string) {}
+func ComputeHash(_ string) string { return "" }
+func LogActivity(_ string) {}

--- a/example/simple.go
+++ b/example/simple.go
@@ -1,20 +1,20 @@
 package example
 
-// データベースアクセスを行う関数
+// GetUserByID performs database access to retrieve user data
 // dirty: { select[user] }
-func GetUserByID(id int64) error {
+func GetUserByID(_ int64) error {
 	// SELECT * FROM users WHERE id = ?
 	return nil
 }
 
-// ログを記録する関数
+// WriteLog records log messages
 // dirty: { insert[log] }
-func WriteLog(message string) error {
+func WriteLog(_ string) error {
 	// INSERT INTO logs (message) VALUES (?)
 	return nil
 }
 
-// 正しい例: 必要なエフェクトをすべて宣言
+// ProcessUser correctly declares all required effects
 // dirty: { select[user] | insert[log] }
 func ProcessUser(id int64) error {
 	if err := GetUserByID(id); err != nil {
@@ -23,7 +23,7 @@ func ProcessUser(id int64) error {
 	return WriteLog("user processed")
 }
 
-// エラーになる例: select[user]エフェクトが不足
+// ProcessUserBroken demonstrates missing effects (error: missing select[user] effect)
 // dirty: { insert[log] }
 func ProcessUserBroken(id int64) error {
 	if err := GetUserByID(id); err != nil {
@@ -32,12 +32,12 @@ func ProcessUserBroken(id int64) error {
 	return WriteLog("user processed")
 }
 
-// 宣言なし関数（チェック対象外だが、暗黙的にエフェクトを持つ）
+// HelperFunction has no declarations but implicitly has effects (not checked but has implicit effects)
 func HelperFunction(id int64) error {
 	return GetUserByID(id)
 }
 
-// エラーになる例: HelperFunctionの暗黙的エフェクトが不足
+// UseHelper demonstrates missing implicit effects (error: missing HelperFunction's implicit effects)
 // dirty: { insert[log] }
 func UseHelper(id int64) error {
 	if err := HelperFunction(id); err != nil {


### PR DESCRIPTION
Fixes #5

This PR addresses lint errors reported in CI by:

- Translating Japanese comments to English for better international accessibility
- Optimizing string concatenation in `joinEffects()` function for improved performance
- Improving overall code readability and maintainability

Generated with [Claude Code](https://claude.ai/code)